### PR TITLE
Enable suggestion of UPPER CASE

### DIFF
--- a/typochecker/corrector.py
+++ b/typochecker/corrector.py
@@ -213,6 +213,8 @@ if __name__ == '__main__':
     # Remove some case sensitivity
     titled_typos = {k.title(): v.title() for k, v in typos.items()}
     typos.update(titled_typos)
+    upper_typos = {k.upper(): v.upper() for k, v in typos.items()}
+    typos.update(upper_typos)
 
     file_beginnings_to_ignore = ['LICENSE']
     file_endings_to_ignore = ['~', '.exe', '.gz', '.jar', '.pdf', '.xml', '.zip']


### PR DESCRIPTION
typochecker.corrector suggests lower caps for an ALL CAPS typo.

```shellsession
$ cat << EOF > typo.txt
Typo: ABILTY
Typo: Abilty
EOF
$ python3 -m typochecker.corrector -d .
Getting list of typos
Information from https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines
opening /tmp/typochecker/typochecker/../data/wikipedia_common_misspellings.txt
opening /tmp/typochecker/typochecker/../data/extra_endings.txt
Will search through 1 files
Suggestions follow for file ./typo.txt
file_typos: ['ABILTY', 'Abilty']
Typo: ABILTY

     ^^^^^^^^^
Suggestion: ability
Correction ("!h" for help), default to ability: 
Typo: Abilty

     ^^^^^^^^^
Suggestion: Ability
Correction ("!h" for help), default to Ability:
```

It would be nice to suggest `ABILITY` instead of `ability`.

This increases `len(typo)` from 13552 to 20389.